### PR TITLE
Update to match lib9ml PR #18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,9 @@ Thumbs.db
 cover
 
 # files from running examples
-examples/Results
-examples/tools/Results
+/examples/Results
+/examples/tools/Results
+/examples/nineml_mechanisms
 
 # Other
 *.btr

--- a/examples/nineml_brunel.py
+++ b/examples/nineml_brunel.py
@@ -1,0 +1,103 @@
+# encoding: utf-8
+"""
+Simulation script for the Brunel (2000) network model as described in NineML.
+
+This script imports a Python lib9ml network description from
+"brunel_network_alpha.py", exports it as XML, and then
+runs a simulation using the pyNN.nineml module with the NEURON
+backend.
+
+"""
+from __future__ import division
+import numpy as np
+from neo import AnalogSignal
+from quantities import ms, dimensionless
+import pyNN.neuron as sim
+from pyNN.nineml.read import Network
+from pyNN.utility import SimulationProgressBar
+from pyNN.utility.plotting import Figure, Panel
+import argparse
+import ninemlcatalog
+
+cases = ['SR', 'SR2', 'SR3', 'SIfast', 'AI', 'SIslow']
+
+parser = argparse.ArgumentParser()
+parser.add_argument('case',
+                    help=("The simulation case to run, can be one of '{}'"
+                          .format("', '".join(cases))))
+parser.add_argument('--local_xml', action='store_true',
+                    help=("Use the local XML definitions instead of the "
+                          "version in the NineML catalog"))
+parser.add_argument('--plot', action='store_true',
+                    help=("Plot the resulting figures"))
+parser.add_argument('--limits', nargs=2, default=(900, 1200),
+                    metavar=('LOW', 'HIGH'),
+                    help="The stop and start time of the plot")
+args = parser.parse_args()
+
+sim.setup()
+
+if args.case not in cases:
+    raise Exception("Unrecognised case '{}', allowed cases are '{}'"
+                    .format("', '".join(cases)))
+
+document = ninemlcatalog.load('/network/Brunel2000/' + args.case)
+xml_file = document.url
+
+print("Building network")
+net = Network(sim, xml_file)
+
+if args.plot:
+    stim = net.populations["Ext"]
+    stim[:100].record('spikes')
+    exc = net.populations["Exc"]
+    exc.sample(50).record("spikes")
+    exc.sample(3).record(["nrn_v", "syn_a"])
+    inh = net.populations["Inh"]
+    inh.sample(50).record("spikes")
+    inh.sample(3).record(["nrn_v", "syn_a"])
+else:
+    all_neurons = net.assemblies["All"]
+    # all.sample(50).record("spikes")
+    all_neurons.record("spikes")
+
+print("Running simulation")
+t_stop = args.limits[1]
+pb = SimulationProgressBar(t_stop / 80, t_stop)
+
+sim.run(t_stop, callbacks=[pb])
+
+print("Handling data")
+if args.plot:
+    stim_data = stim.get_data().segments[0]
+    exc_data = exc.get_data().segments[0]
+    inh_data = inh.get_data().segments[0]
+else:
+    all_neurons.write_data("brunel_network_alpha_%s.h5" % args.case)
+
+sim.end()
+
+
+def instantaneous_firing_rate(segment, begin, end):
+    """Computed in bins of 0.1 ms """
+    bins = np.arange(begin, end, 0.1)
+    hist, _ = np.histogram(segment.spiketrains[0].time_slice(begin, end), bins)
+    for st in segment.spiketrains[1:]:
+        h, _ = np.histogram(st.time_slice(begin, end), bins)
+        hist += h
+    return AnalogSignal(hist, sampling_period=0.1 * ms, units=dimensionless,
+                        channel_index=0, name="Spike count")
+
+if args.plot:
+    Figure(
+        Panel(stim_data.spiketrains, markersize=0.2, xlim=args.limits),
+        Panel(exc_data.analogsignalarrays[0], yticks=True, xlim=args.limits),
+        Panel(exc_data.analogsignalarrays[1], yticks=True, xlim=args.limits),
+        Panel(exc_data.spiketrains[:100], markersize=0.5, xlim=args.limits),
+        Panel(instantaneous_firing_rate(exc_data, *args.limits), yticks=True),
+        Panel(inh_data.analogsignalarrays[0], yticks=True, xlim=args.limits),
+        Panel(inh_data.analogsignalarrays[1], yticks=True, xlim=args.limits),
+        Panel(inh_data.spiketrains[:100], markersize=0.5, xlim=args.limits),
+        Panel(instantaneous_firing_rate(inh_data, *args.limits), xticks=True,
+              xlabel="Time (ms)", yticks=True),
+    ).save("brunel_network_alpha.png")

--- a/examples/nineml_brunel.py
+++ b/examples/nineml_brunel.py
@@ -25,9 +25,6 @@ parser = argparse.ArgumentParser()
 parser.add_argument('case',
                     help=("The simulation case to run, can be one of '{}'"
                           .format("', '".join(cases))))
-parser.add_argument('--local_xml', action='store_true',
-                    help=("Use the local XML definitions instead of the "
-                          "version in the NineML catalog"))
 parser.add_argument('--plot', action='store_true',
                     help=("Plot the resulting figures"))
 parser.add_argument('--limits', nargs=2, default=(900, 1200),

--- a/examples/nineml_neuron.py
+++ b/examples/nineml_neuron.py
@@ -4,11 +4,9 @@ Example of using a cell type defined in 9ML
 
 import sys
 from copy import deepcopy
-from nineml.abstraction_layer.dynamics import (ComponentClass,
-                                               Regime, On, OutputEvent,
-                                               StateVariable, RecvPort,
-                                               ReducePort,
-                                               SendPort, SendEventPort)
+from nineml.abstraction import (
+    Dynamics, Regime, On, OutputEvent, StateVariable, AnalogReceivePort,
+    AnalogReducePort, AnalogSendPort, EventSendPort)
 from pyNN.utility import init_logging, get_simulator, normalized_filename
 
 sim, options = get_simulator(("--plot-figure", "plot a figure with the given filename"))
@@ -18,7 +16,7 @@ init_logging(None, debug=True)
 sim.setup(timestep=0.1, min_delay=0.1, max_delay=2.0)
 
 
-iaf = ComponentClass(
+iaf = Dynamics(
     name="iaf",
     regimes=[
         Regime(
@@ -41,14 +39,14 @@ iaf = ComponentClass(
         StateVariable('V'),
         StateVariable('tspike'),
     ],
-    analog_ports=[SendPort("V"),
-                  ReducePort("ISyn", reduce_op="+"), ],
+    analog_ports=[AnalogSendPort("V"),
+                  AnalogReducePort("ISyn", operator="+"), ],
 
-    event_ports=[SendEventPort('spikeoutput'), ],
+    event_ports=[EventSendPort('spikeoutput'), ],
     parameters=['cm', 'taurefrac', 'gl', 'vreset', 'vrest', 'vthresh']
 )
 
-coba = ComponentClass(
+coba = Dynamics(
     name="CobaSyn",
     aliases=["I:=g*(vrev-V)", ],
     regimes=[
@@ -59,11 +57,11 @@ coba = ComponentClass(
         )
     ],
     state_variables=[StateVariable('g')],
-    analog_ports=[RecvPort("V"), SendPort("I"), ],
+    analog_ports=[AnalogReceivePort("V"), AnalogSendPort("I"), ],
     parameters=['tau', 'q', 'vrev']
 )
 
-iaf_2coba = ComponentClass(
+iaf_2coba = Dynamics(
     name="iaf_2coba",
     subnodes={"iaf": iaf,
               "excitatory": coba,

--- a/pyNN/nest/nineml.py
+++ b/pyNN/nest/nineml.py
@@ -65,8 +65,8 @@ class _nest_build_nineml_celltype(type):
     """
     def __new__(cls, name, bases, dct):
         
-        import nineml.abstraction_layer as al
-        from nineml.abstraction_layer import flattening, writers, component_modifiers
+        import nineml.abstraction as al
+        from nineml.abstraction import flattening, writers, component_modifiers
         import nest
 
         #Extract Parameters Back out from Dict:

--- a/pyNN/nineml/__init__.py
+++ b/pyNN/nineml/__init__.py
@@ -4,13 +4,12 @@ Export of PyNN scripts as NineML.
 :copyright: Copyright 2006-2015 by the PyNN team, see AUTHORS.
 :license: CeCILL, see LICENSE for details.
 """
-from __future__ import absolute_import
 import logging
 import nineml.user as ul
 from neo.io import get_io
 
 from .. import common, random, standardmodels as std
-from .simulator import state
+from . import simulator
 from .standardmodels import *
 from .populations import Population, PopulationView, Assembly
 from .projections import Projection
@@ -27,25 +26,25 @@ def list_standard_models():
 
 def setup(timestep=0.1, min_delay=0.1, max_delay=10.0, **extra_params):
     common.setup(timestep, min_delay, max_delay, **extra_params)
-    state.clear()
-    state.dt = timestep  # move to common.setup?
-    state.min_delay = min_delay
-    state.max_delay = max_delay
-    state.mpi_rank = extra_params.get('rank', 0)
-    state.num_processes = extra_params.get('num_processes', 1)
-    state.output_filename = extra_params.get("filename", "PyNN29ML.xml")
-    state.net = Network(label=extra_params.get("label", "PyNN29ML"))
+    simulator.state.clear()
+    simulator.state.dt = timestep  # move to common.setup?
+    simulator.state.min_delay = min_delay
+    simulator.state.max_delay = max_delay
+    simulator.state.mpi_rank = extra_params.get('rank', 0)
+    simulator.state.num_processes = extra_params.get('num_processes', 1)
+    simulator.state.output_filename = extra_params.get("filename", "PyNN29ML.xml")
+    simulator.state.net = Network(label=extra_params.get("label", "PyNN29ML"))
     return rank()
 
 
 def end(compatible_output=True):
     """Do any necessary cleaning up before exiting."""
-    for (population, variables, filename) in state.write_on_end:
+    for (population, variables, filename) in simulator.state.write_on_end:
         io = get_io(filename)
         population.write_data(io, variables)
-    state.write_on_end = []
+    simulator.state.write_on_end = []
     # should have common implementation of end()
-    state.net.to_nineml().write(state.output_filename)
+    simulator.state.net.to_nineml().write(simulator.state.output_filename)
 
 
 run = common.build_run(simulator)
@@ -88,7 +87,7 @@ class Network(object):  # move to .simulator ?
             model.add_component(cs.to_nineml())
             # needToDefineWhichCellsTheCurrentIsInjectedInto
             # doWeJustReuseThePopulationProjectionIdiom="?"
-        main_group = ul.Group(name="Network")
+        main_group = ul.Network(name="Network")
         _populations = self.populations[:]
         _projections = self.projections[:]
         for a in self.assemblies:

--- a/pyNN/nineml/cells.py
+++ b/pyNN/nineml/cells.py
@@ -7,7 +7,7 @@ Cell models generated from 9ML
 
 import logging
 from itertools import chain
-import nineml.abstraction_layer as nineml
+import nineml.abstraction as nineml
 from pyNN.models import BaseCellType
 
 logger = logging.getLogger("PyNN")
@@ -74,8 +74,8 @@ class build_nineml_celltype(type):
     """
     def __new__(cls, name, bases, dct):
 
-        import nineml.abstraction_layer as al
-        from nineml.abstraction_layer.dynamics.utils import (
+        import nineml.abstraction as al
+        from nineml.abstraction.dynamics.utils import (
             flattener, xml, modifiers)
 
         #Extract Parameters Back out from Dict:

--- a/pyNN/nineml/connectors.py
+++ b/pyNN/nineml/connectors.py
@@ -5,19 +5,19 @@ Export of PyNN scripts as NineML.
 :license: CeCILL, see LICENSE for details.
 """
 
-import nineml.user_layer as nineml
+import nineml.user as nineml
 
 from pyNN import connectors
 from utility import build_parameter_set, catalog_url
 
-    
+
 class ConnectorMixin(object):
-    
+
     def to_nineml(self, label):
         connector_parameters = {}
         for name in self.__class__.parameter_names:
             connector_parameters[name] = getattr(self, name)
-        connection_rule = nineml.ConnectionRule(
+        connection_rule = nineml.ConnectionRuleComponent(
                                     name="connection rule for projection %s" % label,
                                     definition=nineml.Definition(self.definition_url,
                                                                  "connection_generator"),
@@ -28,8 +28,8 @@ class ConnectorMixin(object):
 class FixedProbabilityConnector(ConnectorMixin, connectors.FixedProbabilityConnector):
     definition_url = "%s/connectionrules/random_fixed_probability.xml" % catalog_url 
     parameter_names = ('p_connect', 'allow_self_connections')
-   
-   
+
+
 class DistanceDependentProbabilityConnector(ConnectorMixin, connectors.DistanceDependentProbabilityConnector):
     definition_url = "%s/connectionrules/distance_dependent_probability.xml" % catalog_url
     parameter_names = ('d_expression', 'allow_self_connections') # space

--- a/pyNN/nineml/populations.py
+++ b/pyNN/nineml/populations.py
@@ -6,7 +6,7 @@ Export of PyNN scripts as NineML.
 """
 
 import numpy
-import nineml.user_layer as nineml
+import nineml.user as nineml
 
 from pyNN import common
 from pyNN.standardmodels import StandardCellType
@@ -17,7 +17,7 @@ from .utility import build_parameter_set, catalog_url
 
 
 class BasePopulation(object):
-    
+
     def get_synaptic_response_components(self, synaptic_mechanism_name):
         return [self.celltype.synaptic_receptor_component_to_nineml(synaptic_mechanism_name, self.label, (self.size,))]
 
@@ -27,11 +27,11 @@ class BasePopulation(object):
 
 class Assembly(common.Assembly):
     _simulator = simulator
-    
+
     def __init__(self, label=None, *populations):
         common.Assembly.__init__(self, label, *populations)
         self._simulator.state.net.assemblies.append(self)
-        
+
     def get_synaptic_response_components(self, synaptic_mechanism_name):
         components = set([])
         for p in self.populations:
@@ -87,14 +87,14 @@ class Population(BasePopulation, common.Population):
         def is_local(id):
             return (id % simulator.state.num_processes) == simulator.state.mpi_rank
         self._mask_local = is_local(self.all_cells)
-        
+
         if isinstance(self.celltype, StandardCellType):
             parameter_space = self.celltype.native_parameters
         else:
             parameter_space = self.celltype.parameter_space
         parameter_space.shape = (self.size,)
         self._parameters = parameter_space
-        
+
         for id in self.all_cells:
             id.parent = self
         self._simulator.state.id_counter += self.size
@@ -105,7 +105,7 @@ class Population(BasePopulation, common.Population):
     def _set_parameters(self, parameter_space):
         """parameter_space should contain native parameters"""
         self._parameters.update(parameter_space)
-    
+
     def to_nineml(self):
         if self.structure:
             structure = nineml.Structure(

--- a/pyNN/nineml/projections.py
+++ b/pyNN/nineml/projections.py
@@ -7,7 +7,7 @@ Export of PyNN scripts as NineML.
 """
 
 from itertools import repeat, izip
-import nineml.user_layer as nineml
+import nineml.user as nineml
 
 from pyNN import common
 from pyNN.parameters import ParameterSpace

--- a/pyNN/nineml/utility.py
+++ b/pyNN/nineml/utility.py
@@ -9,7 +9,7 @@ from os.path import join, dirname
 from lazyarray import larray
 from pyNN import random
 from pyNN.parameters import Sequence
-import nineml.user_layer as nineml
+import nineml.user as nineml
 
 #catalog_url = "http://svn.incf.org/svn/nineml/catalog"
 #catalog_url = join(dirname(__file__), "catalog")
@@ -41,15 +41,15 @@ def infer_units(parameter_name):
     return unit
 
 random_distribution_url_map = {
-    'uniform': "%s/randomdistributions/uniform_distribution.xml" % catalog_url,
-    'normal': "%s/randomdistributions/normal_distribution.xml" % catalog_url,
-    'exponential': "%s/randomdistributions/exponential_distribution.xml" % catalog_url,
+    'uniform': 'http://www.uncertml.org/distributions/uniform.xml',
+    'normal': 'http://www.uncertml.org/distributions/normal.xml',
+    'exponential': 'http://www.uncertml.org/distributions/exponential.xml',
 }
 
 random_distribution_parameter_map = {
-    'normal': ('mean', 'standardDeviation'),
-    'uniform': ('lowerBound', 'upperBound'),
-    'exponential': ('beta',),
+    'normal': ('mean', 'variance'),
+    'uniform': ('minimum', 'maximum'),
+    'exponential': ('rate',),
 }
 
 
@@ -66,7 +66,7 @@ def build_parameter_set(parameters, shape=None, dimensionless=False):
                     value = int(value)
             elif isinstance(value, random.RandomDistribution):
                 rand_distr = value
-                value = nineml.RandomDistribution(
+                value = nineml.RandomDistributionComponent(
                     name="%s(%s)" % (rand_distr.name, ",".join(str(p) for p in rand_distr.parameters)),
                     definition=nineml.Definition(random_distribution_url_map[rand_distr.name],
                                                  "random"),
@@ -83,8 +83,8 @@ def build_parameter_set(parameters, shape=None, dimensionless=False):
             unit = None
         else:
             unit = infer_units(name)
-        parameter_list.append(nineml.Parameter(name, value, unit))
-    return nineml.ParameterSet(*parameter_list)
+        parameter_list.append(nineml.Property(name, value, unit))
+    return nineml.PropertySet(*parameter_list)
 
 
 def map_random_distribution_parameters(name, parameters):

--- a/src/nineml/catalog/build_catalog.py
+++ b/src/nineml/catalog/build_catalog.py
@@ -5,7 +5,7 @@ the NineML description of that model as XML.
 """
 
 from os import path, makedirs
-from nineml.abstraction_layer.writers.xml_writer import XMLWriter
+from nineml.abstraction.writers.xml_writer import XMLWriter
 import pyNN.nineml
 from pyNN.nineml import list_standard_models
 from pyNN.nineml.utility import catalog_url


### PR DESCRIPTION
- Updates PyNN/nineml package to new lib9ML syntax ((._)_layer-> \1, (._)Class -> \1, etc) (see https://github.com/INCF/lib9ML/pull/18)
- Fixes dimension-checking failures in example models
- Adds example script for reading Brunel network from NineML catalog
- Fixes lookup of PyNN random distribution from RandomDistributionComponents
