### PR TITLE
Allowing the recording of conductances for multisynapse model in nest + implementation of 2-exponential synapse model

### DIFF
--- a/examples/multi_synapse.py
+++ b/examples/multi_synapse.py
@@ -41,7 +41,8 @@ celltype = sim.PointNeuron(
                 GABAB=sim.AlphaPSR(tau_syn=15.0, e_syn=-90.0))
 
 neurons = sim.Population(1, celltype, initial_values={'v': -60.0})
-neurons.record(['v'])  #, 'AMPA.gsyn', 'NMDA.gsyn', 'GABAA.gsyn', 'GABAB.gsyn'])
+
+neurons.record(['v', 'AMPA_gsyn', 'NMDA_gsyn', 'GABAA_gsyn', 'GABAB_gsyn'])  #, 'AMPA.gsyn', 'NMDA.gsyn', 'GABAA.gsyn', 'GABAB.gsyn'])
 
 print("tau_m = ", neurons.get("tau_m"))
 print("GABAA.e_syn = ", neurons.get("GABAA.e_syn"))
@@ -65,7 +66,6 @@ connections = {
                            synapse_type=sim.StaticSynapse(weight=0.005, delay=1.5),
                            receptor_type="NMDA", label="NMDA"),
 }
-
 # === Run the simulation =====================================================
 
 sim.run(200.0)
@@ -85,14 +85,55 @@ if options.plot_figure:
               ylabel="Membrane potential (mV)",
               xticks=True, xlabel="Time (ms)",
               yticks=True), #ylim=(-66, -48)),
-        # Panel(data.filter(name='AMPA.gsyn')[0],
-        #       xticks=True, xlabel="Time (ms)",
-        #       ylabel="u (mV/ms)",
-        #       yticks=True),
         title="Neuron with multiple synapse time constants",
         annotations="Simulated with %s" % options.simulator.upper()
     ).save(figure_filename)
     print(figure_filename)
+
+    figure_filename_cond_ampa = filename.replace(".pkl", "_cond_ampa.png")
+    Figure(
+         Panel(data.filter(name='AMPA_gsyn')[0],
+               xticks=True, xlabel="Time (ms)",
+               ylabel="AMPA Conductance (uS)",
+               yticks=True),
+        title="Neuron with multiple synapse time constants",
+        annotations="Simulated with %s" % options.simulator.upper()
+    ).save(figure_filename_cond_ampa)
+    print(figure_filename_cond_ampa)
+
+    figure_filename_cond_nmda = filename.replace(".pkl", "_cond_nmda.png")
+    Figure(
+         Panel(data.filter(name='NMDA_gsyn')[0],
+               xticks=True, xlabel="Time (ms)",
+               ylabel="NMDA Conductance (uS)",
+               yticks=True),
+        title="Neuron with multiple synapse time constants",
+        annotations="Simulated with %s" % options.simulator.upper()
+    ).save(figure_filename_cond_nmda)
+    print(figure_filename_cond_nmda)
+
+    figure_filename_cond_gabaa = filename.replace(".pkl", "_cond_gabaa.png")
+    Figure(
+         Panel(data.filter(name='GABAA_gsyn')[0],
+               xticks=True, xlabel="Time (ms)",
+               ylabel="GABAA Conductance (uS)",
+               yticks=True),
+        title="Neuron with multiple synapse time constants",
+        annotations="Simulated with %s" % options.simulator.upper()
+    ).save(figure_filename_cond_gabaa)
+    print(figure_filename_cond_gabaa)
+
+    figure_filename_cond_gabab = filename.replace(".pkl", "_cond_gabab.png")
+    Figure(
+         Panel(data.filter(name='GABAB_gsyn')[0],
+               xticks=True, xlabel="Time (ms)",
+               ylabel="GABAB Conductance (uS)",
+               yticks=True),
+        title="Neuron with multiple synapse time constants",
+        annotations="Simulated with %s" % options.simulator.upper()
+    ).save(figure_filename_cond_gabab)
+    print(figure_filename_cond_gabab)
+
 
 # === Clean up and quit ========================================================
 

--- a/pyNN/nest/cells.py
+++ b/pyNN/nest/cells.py
@@ -20,6 +20,12 @@ UNITS_MAP = {
     'I_syn_in': 'pA'
 }
 
+VARIABLE_MAP = {'v': 'V_m', 'gsyn_exc': 'g_ex', 'gsyn_inh': 'g_in', 'u': 'U_m',
+                'w': 'w', 'i_eta': 'I_stc', 'v_t': 'E_sfa'}
+REVERSE_VARIABLE_MAP = dict((v, k) for k, v in VARIABLE_MAP.items())
+SCALE_FACTORS = {'v': 1, 'gsyn_exc': 0.001,
+                 'gsyn_inh': 0.001, 'w': 0.001, 'i_eta': 0.001, 'v_t': 1}
+
 
 def get_defaults(model_name):
     valid_types = (int, float, Sequence, np.ndarray)
@@ -77,6 +83,9 @@ def native_cell_type(model_name):
                  'injectable': ("V_m" in default_initial_values),
                  'recordable': recordable,
                  'units': dict(((var, UNITS_MAP.get(var, 'unknown')) for var in recordable)),
+                 'variable_map': VARIABLE_MAP,
+                 'reverse_variable_map': REVERSE_VARIABLE_MAP,
+                 'scale_factors': SCALE_FACTORS,
                  'standard_receptor_type': (receptor_types == ['excitatory', 'inhibitory']),
                  'nest_name': {"on_grid": model_name, "off_grid": model_name},
                  'conductance_based': ("g" in (s[0] for s in recordable)),

--- a/pyNN/nest/populations.py
+++ b/pyNN/nest/populations.py
@@ -16,7 +16,7 @@ from pyNN.parameters import ArrayParameter, Sequence, ParameterSpace, simplify, 
 from pyNN.random import RandomDistribution
 from pyNN.standardmodels import StandardCellType
 from . import simulator
-from .recording import Recorder, VARIABLE_MAP
+from .recording import Recorder
 
 logger = logging.getLogger("PyNN")
 
@@ -254,7 +254,7 @@ class Population(common.Population, PopulationMixin):
                     self._simulator.set_status(self.node_collection, name, value)
 
     def _set_initial_value_array(self, variable, value):
-        variable = VARIABLE_MAP.get(variable, variable)
+        variable = self.celltype.variable_map.get(variable, variable)
         if isinstance(value.base_value, RandomDistribution) and value.base_value.rng.parallel_safe:
             local_values = value.evaluate()[self._mask_local]
         else:

--- a/pyNN/nest/recording.py
+++ b/pyNN/nest/recording.py
@@ -13,13 +13,6 @@ import nest
 from pyNN import recording, errors
 from pyNN.nest import simulator
 
-# todo: this information should come from the cell type classes
-VARIABLE_MAP = {'v': 'V_m', 'gsyn_exc': 'g_ex', 'gsyn_inh': 'g_in', 'u': 'U_m',
-                'w': 'w', 'i_eta': 'I_stc', 'v_t': 'E_sfa'}
-REVERSE_VARIABLE_MAP = dict((v, k) for k, v in VARIABLE_MAP.items())
-SCALE_FACTORS = {'v': 1, 'gsyn_exc': 0.001,
-                 'gsyn_inh': 0.001, 'w': 0.001, 'i_eta': 0.001, 'v_t': 1}
-
 logger = logging.getLogger("PyNN")
 
 
@@ -51,13 +44,11 @@ class RecordingDevice(object):
         assert not self._connected
         self._all_ids = self._all_ids.union(new_ids)
 
-    def get_data(self, variable, desired_ids, clear=False):
+    def get_data(self, variable, nest_variable, scale_factor, desired_ids, clear=False):
         """
         Return recorded data as a dictionary containing one numpy array for
         each neuron, ids as keys.
         """
-        scale_factor = SCALE_FACTORS.get(variable, 1)
-        nest_variable = VARIABLE_MAP.get(variable, variable)
         events = nest.GetStatus(self.device, 'events')[0]
         ids = events['senders']
         times = events["times"] - simulator.state._time_offset
@@ -149,7 +140,7 @@ class SpikeDetector(RecordingDevice):
 
         Equivalent to `get_data('times', desired_ids)`
         """
-        return self.get_data('times', desired_ids, clear=clear)
+        return self.get_data('times', 'times', 1, desired_ids, clear=clear)
 
     def get_spike_counts(self, desired_ids):
         events = nest.GetStatus(self.device, 'events')[0]
@@ -186,7 +177,7 @@ class Multimeter(RecordingDevice):
 
     def add_variable(self, variable):
         current_variables = self.variables
-        current_variables.add(VARIABLE_MAP.get(variable, variable))
+        current_variables.add(variable)
         _set_status(self.device, {'record_from': list(current_variables)})
 
 
@@ -235,7 +226,8 @@ class Recorder(recording.Recorder):
             self._spike_detector.add_ids(new_ids)
         else:
             self.sampling_interval = sampling_interval
-            self._multimeter.add_variable(variable)
+            nest_variable = self.population.celltype.variable_map.get(variable, variable)
+            self._multimeter.add_variable(nest_variable)
             self._multimeter.add_ids(new_ids)
 
     def _get_sampling_interval(self):
@@ -262,7 +254,9 @@ class Recorder(recording.Recorder):
         return self._spike_detector.get_spiketimes(ids, clear=clear)
 
     def _get_all_signals(self, variable, ids, clear=False):
-        data = self._multimeter.get_data(variable, ids, clear=clear)
+        nest_variable = self.population.celltype.variable_map.get(variable, variable) 
+        scale_factor = self.population.celltype.scale_factors.get(variable, 1) 
+        data = self._multimeter.get_data(variable, nest_variable, scale_factor, ids, clear=clear)
         if len(ids) > 0:
             # JACOMMENT: this is very expensive but not sure how to get rid of it
             return np.array([data[i] for i in ids]).T

--- a/pyNN/nest/standardmodels/cells.py
+++ b/pyNN/nest/standardmodels/cells.py
@@ -427,15 +427,17 @@ class AdExp(cells.AdExp):
 class PointNeuron(cells.PointNeuron, NestCellsMixin):
     standard_receptor_type = False
 
-    def __init__(self, neuron, **post_synaptic_receptors):
-        super(PointNeuron, self).__init__(neuron, **post_synaptic_receptors)
-        for i, name in enumerate(self.post_synaptic_receptors.keys()):
-            pynn_name = '{}_gsyn'.format(name)
-            nest_name = 'g_{}'.format(i + 1)
-            self.variable_map[pynn_name] = nest_name
-            self.reverse_variable_map[nest_name] = pynn_name
-            self.scale_factors[pynn_name] = 0.001 
-            self.units[pynn_name] = 'uS'
+    #def __init__(self, neuron, **post_synaptic_receptors):
+    #    super(PointNeuron, self).__init__(neuron, **post_synaptic_receptors)
+    #    for i, name in enumerate(self.post_synaptic_receptors.keys()):
+    #        pynn_name = '{}_gsyn'.format(name)
+    #        nest_name = 'g_{}'.format(i + 1)
+    #        self.variable_map[pynn_name] = nest_name
+    #        self.reverse_variable_map[nest_name] = pynn_name
+    #        self.scale_factors[pynn_name] = 0.001 
+    #        self.units[pynn_name] = 'uS'
+    #        self.neuron.default_initial_values[nest_name] = 0.0
+
 
     def get_receptor_type(self, name):
         return self.receptor_types.index(name) + 1  # port numbers start at 1
@@ -524,3 +526,13 @@ class PointNeuron(cells.PointNeuron, NestCellsMixin):
     def reverse_translate(self, native_parameters):
         standard_parameters = self.neuron.reverse_translate(native_parameters)
         return standard_parameters
+
+    def attributes_psr_update(self, psr):
+        pynn_name = '{}_gsyn'.format(psr)
+        nest_name = 'g_{}'.format(self.get_receptor_type(psr))
+        self.variable_map[pynn_name] = nest_name
+        self.reverse_variable_map[nest_name] = pynn_name
+        self.scale_factors[pynn_name] = 0.001
+        self.units[pynn_name] = 'uS'
+        self.neuron.default_initial_values[pynn_name] = 0.0
+

--- a/pyNN/nest/standardmodels/cells.py
+++ b/pyNN/nest/standardmodels/cells.py
@@ -427,18 +427,6 @@ class AdExp(cells.AdExp):
 class PointNeuron(cells.PointNeuron, NestCellsMixin):
     standard_receptor_type = False
 
-    #def __init__(self, neuron, **post_synaptic_receptors):
-    #    super(PointNeuron, self).__init__(neuron, **post_synaptic_receptors)
-    #    for i, name in enumerate(self.post_synaptic_receptors.keys()):
-    #        pynn_name = '{}_gsyn'.format(name)
-    #        nest_name = 'g_{}'.format(i + 1)
-    #        self.variable_map[pynn_name] = nest_name
-    #        self.reverse_variable_map[nest_name] = pynn_name
-    #        self.scale_factors[pynn_name] = 0.001 
-    #        self.units[pynn_name] = 'uS'
-    #        self.neuron.default_initial_values[nest_name] = 0.0
-
-
     def get_receptor_type(self, name):
         return self.receptor_types.index(name) + 1  # port numbers start at 1
 

--- a/pyNN/nest/standardmodels/cells.py
+++ b/pyNN/nest/standardmodels/cells.py
@@ -412,7 +412,7 @@ class AdExp(cells.AdExp):
     )
     #nest_name = {"on_grid": "aeif_cond_alpha_multisynapse",
     #             "off_grid": "aeif_cond_alpha_multisynapse"}
-    possible_models = set(["aeif_cond_alpha_multisynapse"])
+    possible_models = set(["aeif_cond_alpha_multisynapse","aeif_cond_beta_multisynapse"])
     standard_receptor_type = False
 
 

--- a/pyNN/nest/standardmodels/cells.py
+++ b/pyNN/nest/standardmodels/cells.py
@@ -16,8 +16,15 @@ from .. import simulator
 
 logger = logging.getLogger("PyNN")
 
+class NestCellsMixin(object):
+    variable_map = {'v': 'V_m', 'gsyn_exc': 'g_ex', 'gsyn_inh': 'g_in', 'u': 'U_m',
+                    'w': 'w', 'i_eta': 'I_stc', 'v_t': 'E_sfa'}
+    reverse_variable_map = dict((v, k) for k, v in variable_map.items())
+    scale_factors = {'v': 1, 'gsyn_exc': 0.001,
+                     'gsyn_inh': 0.001, 'w': 0.001, 'i_eta': 0.001, 'v_t': 1}
 
-class IF_curr_alpha(cells.IF_curr_alpha):
+
+class IF_curr_alpha(cells.IF_curr_alpha, NestCellsMixin):
 
     __doc__ = cells.IF_curr_alpha.__doc__
 
@@ -32,12 +39,13 @@ class IF_curr_alpha(cells.IF_curr_alpha):
         ('v_thresh',   'V_th'),
         ('i_offset',   'I_e',      1000.0),  # I_e is in pA, i_offset in nA
     )
+
     nest_name = {"on_grid": "iaf_psc_alpha",
                  "off_grid": "iaf_psc_alpha"}
     standard_receptor_type = True
 
 
-class IF_curr_exp(cells.IF_curr_exp):
+class IF_curr_exp(cells.IF_curr_exp, NestCellsMixin):
 
     __doc__ = cells.IF_curr_exp.__doc__
 
@@ -57,7 +65,7 @@ class IF_curr_exp(cells.IF_curr_exp):
     standard_receptor_type = True
 
 
-class IF_cond_alpha(cells.IF_cond_alpha):
+class IF_cond_alpha(cells.IF_cond_alpha, NestCellsMixin):
 
     __doc__ = cells.IF_cond_alpha.__doc__
 
@@ -79,7 +87,7 @@ class IF_cond_alpha(cells.IF_cond_alpha):
     standard_receptor_type = True
 
 
-class IF_cond_exp(cells.IF_cond_exp):
+class IF_cond_exp(cells.IF_cond_exp, NestCellsMixin):
 
     __doc__ = cells.IF_cond_exp.__doc__
 
@@ -101,7 +109,7 @@ class IF_cond_exp(cells.IF_cond_exp):
     standard_receptor_type = True
 
 
-class IF_cond_exp_gsfa_grr(cells.IF_cond_exp_gsfa_grr):
+class IF_cond_exp_gsfa_grr(cells.IF_cond_exp_gsfa_grr, NestCellsMixin):
 
     __doc__ = cells.IF_cond_exp_gsfa_grr.__doc__
 
@@ -129,7 +137,7 @@ class IF_cond_exp_gsfa_grr(cells.IF_cond_exp_gsfa_grr):
     standard_receptor_type = True
 
 
-class IF_facets_hardware1(cells.IF_facets_hardware1):
+class IF_facets_hardware1(cells.IF_facets_hardware1, NestCellsMixin):
 
     __doc__ = cells.IF_facets_hardware1.__doc__
 
@@ -154,7 +162,7 @@ class IF_facets_hardware1(cells.IF_facets_hardware1):
     }
 
 
-class HH_cond_exp(cells.HH_cond_exp):
+class HH_cond_exp(cells.HH_cond_exp, NestCellsMixin):
 
     __doc__ = cells.HH_cond_exp.__doc__
 
@@ -178,7 +186,7 @@ class HH_cond_exp(cells.HH_cond_exp):
     standard_receptor_type = True
 
 
-class EIF_cond_alpha_isfa_ista(cells.EIF_cond_alpha_isfa_ista):
+class EIF_cond_alpha_isfa_ista(cells.EIF_cond_alpha_isfa_ista, NestCellsMixin):
 
     __doc__ = cells.EIF_cond_alpha_isfa_ista.__doc__
 
@@ -325,7 +333,7 @@ class SpikeSourceArray(cells.SpikeSourceArray):
     always_local = True
 
 
-class EIF_cond_exp_isfa_ista(cells.EIF_cond_exp_isfa_ista):
+class EIF_cond_exp_isfa_ista(cells.EIF_cond_exp_isfa_ista, NestCellsMixin):
 
     __doc__ = cells.EIF_cond_exp_isfa_ista.__doc__
 
@@ -352,7 +360,7 @@ class EIF_cond_exp_isfa_ista(cells.EIF_cond_exp_isfa_ista):
     standard_receptor_type = True
 
 
-class Izhikevich(cells.Izhikevich):
+class Izhikevich(cells.Izhikevich, NestCellsMixin):
     __doc__ = cells.Izhikevich.__doc__
 
     translations = build_translations(
@@ -368,7 +376,7 @@ class Izhikevich(cells.Izhikevich):
     receptor_scale = 1e-3  # synaptic weight is in mV, so need to undo usual weight scaling
 
 
-class GIF_cond_exp(cells.GIF_cond_exp):
+class GIF_cond_exp(cells.GIF_cond_exp, NestCellsMixin):
 
     translations = build_translations(
         ('v_rest',     'E_L'),
@@ -416,8 +424,18 @@ class AdExp(cells.AdExp):
     standard_receptor_type = False
 
 
-class PointNeuron(cells.PointNeuron):
+class PointNeuron(cells.PointNeuron, NestCellsMixin):
     standard_receptor_type = False
+
+    def __init__(self, neuron, **post_synaptic_receptors):
+        super(PointNeuron, self).__init__(neuron, **post_synaptic_receptors)
+        for i, name in enumerate(self.post_synaptic_receptors.keys()):
+            pynn_name = '{}_gsyn'.format(name)
+            nest_name = 'g_{}'.format(i + 1)
+            self.variable_map[pynn_name] = nest_name
+            self.reverse_variable_map[nest_name] = pynn_name
+            self.scale_factors[pynn_name] = 0.001 
+            self.units[pynn_name] = 'uS'
 
     def get_receptor_type(self, name):
         return self.receptor_types.index(name) + 1  # port numbers start at 1

--- a/pyNN/nest/standardmodels/receptors.py
+++ b/pyNN/nest/standardmodels/receptors.py
@@ -9,4 +9,14 @@ class CondAlphaPostSynapticResponse(receptors.CondAlphaPostSynapticResponse):
         ('tau_syn', 'tau_syn')
     )
 
+class CondBetaPostSynapticResponse(receptors.CondBetaPostSynapticResponse):
+    possible_models = set(["aeif_cond_beta_multisynapse"])
+
+    translations = build_translations(
+        ('e_syn', 'E_rev'),
+        ('tau_rise', 'tau_rise'),
+        ('tau_decay', 'tau_decay')
+    )
+
 AlphaPSR = CondAlphaPostSynapticResponse  # alias
+BetaPSR = CondBetaPostSynapticResponse  # alias

--- a/pyNN/standardmodels/cells.py
+++ b/pyNN/standardmodels/cells.py
@@ -539,6 +539,7 @@ class PointNeuron(StandardCellType):
         self.post_synaptic_receptors = post_synaptic_receptors
         for psr in post_synaptic_receptors.values():
             psr.set_parent(self)
+            self.variable_map_update(psr)
         self.parameter_space = deepcopy(self.neuron.parameter_space)
         for name, psr in self.post_synaptic_receptors.items():
             self.parameter_space.add_child(name, psr.parameter_space)
@@ -549,7 +550,7 @@ class PointNeuron(StandardCellType):
 
     @property
     def recordable(self):
-        return ['spikes', 'v', 'w']  #+ ['{}.gsyn'.format(name) for name in self.receptor_types]
+        return ['spikes', 'v', 'w']  + ['{}_gsyn'.format(name) for name in self.receptor_types]
 
     @property
     def units(self):
@@ -581,6 +582,9 @@ class PointNeuron(StandardCellType):
         return self.neuron.computed_parameters_include(parameter_names) or reduce(operator.or_,
                                                                                   [psr.computed_parameters_include(parameter_names)
                                                                                    for psr in self.post_synaptic_receptors.values()])
+    def variable_map_update(self, variable):
+        pass
+
 
 
 class Izhikevich(StandardCellType):

--- a/pyNN/standardmodels/cells.py
+++ b/pyNN/standardmodels/cells.py
@@ -539,10 +539,10 @@ class PointNeuron(StandardCellType):
         self.post_synaptic_receptors = post_synaptic_receptors
         for psr in post_synaptic_receptors.values():
             psr.set_parent(self)
-            self.variable_map_update(psr)
         self.parameter_space = deepcopy(self.neuron.parameter_space)
         for name, psr in self.post_synaptic_receptors.items():
             self.parameter_space.add_child(name, psr.parameter_space)
+            self.attributes_psr_update(name)
 
     @property
     def receptor_types(self):
@@ -582,7 +582,8 @@ class PointNeuron(StandardCellType):
         return self.neuron.computed_parameters_include(parameter_names) or reduce(operator.or_,
                                                                                   [psr.computed_parameters_include(parameter_names)
                                                                                    for psr in self.post_synaptic_receptors.values()])
-    def variable_map_update(self, variable):
+    def attributes_psr_update(self, psr):
+        """Update the attributes based on the given post-synaptic receptor"""
         pass
 
 

--- a/pyNN/standardmodels/receptors.py
+++ b/pyNN/standardmodels/receptors.py
@@ -15,3 +15,15 @@ class CondAlphaPostSynapticResponse(StandardPostSynapticResponse):
         'e_syn': 0.0,   # synaptic reversal potential in mV.
         'tau_syn': 5.0  # time constant of the synaptic conductance in ms.
     }
+
+class CondBetaPostSynapticResponse(StandardPostSynapticResponse):
+    """
+    
+    """
+
+    default_parameters = {
+        'e_syn': 0.0,   # synaptic reversal potential in mV.
+        'tau_rise': 0.2,  # rise time constant of the synaptic conductance in ms.
+        'tau_decay': 1.7  # decay time constant of the synaptic conductance in ms.
+    }
+


### PR DESCRIPTION
To allow the possibility the recording of conductances of multisynapse models, the VARIABLE_MAP, REVERSE_VARIABLE_MAP and SCALE_FACTORS variables were moved from the pyNN/nest/recording.py file to the nest cell type classes.

When creating a multisynapse model, the method attributes_psr_update is called which update these variables so that `g_n` is translated in PyNN in `NAME_gsyn` where `NAME` is the name of the receptor of nest index `n` defined when instantiating the multisynapse celltype. The same method also sets the unit of the corresponding variables and their initial values.